### PR TITLE
Pass index and array to comparator

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Example
 Be advised that passing in a comparator function is *required*. Since you're
 probably using one for your sort function anyway, this isn't a big deal.
 
+The comparator will also be called with a third argument, the index of the current value. You shouldn't normally need the index, but it's there if you do.
+
 You may also, optionally, specify an input range as the final two parameters,
 in case you want to limit the search to a particular range of inputs. However,
 be advised that this is generally a bad idea (but sometimes bad ideas are

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Example
 Be advised that passing in a comparator function is *required*. Since you're
 probably using one for your sort function anyway, this isn't a big deal.
 
-The comparator will also be called with a third argument, the index of the current value. You shouldn't normally need the index, but it's there if you do.
+The 3rd and 4th arguments to the comparator are the current index and array, respectively. You shouldn't normally need the index or array to compare values, but it's there if you do.
 
 You may also, optionally, specify an input range as the final two parameters,
 in case you want to limit the search to a particular range of inputs. However,

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ module.exports = function(haystack, needle, comparator, low, high) {
     /* Note that "(low + high) >>> 1" may overflow, and results in a typecast
      * to double (which gives the wrong results). */
     mid = low + (high - low >> 1);
-    cmp = +comparator(haystack[mid], needle);
+    cmp = +comparator(haystack[mid], needle, mid);
 
     /* Too low. */
     if(cmp < 0.0)

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ module.exports = function(haystack, needle, comparator, low, high) {
     /* Note that "(low + high) >>> 1" may overflow, and results in a typecast
      * to double (which gives the wrong results). */
     mid = low + (high - low >> 1);
-    cmp = +comparator(haystack[mid], needle, mid);
+    cmp = +comparator(haystack[mid], needle, mid, haystack);
 
     /* Too low. */
     if(cmp < 0.0)

--- a/package.json
+++ b/package.json
@@ -12,7 +12,10 @@
     "url": "git://github.com/darkskyapp/binary-search.git"
   },
   "devDependencies": {
-    "mocha": "1.9.x",
-    "chai": "1.6.x"
+    "chai": "^3.5.0",
+    "mocha": "^2.4.5"
+  },
+  "scripts": {
+    "test": "mocha"
   }
 }

--- a/test.js
+++ b/test.js
@@ -32,4 +32,11 @@ describe("binarysearch", function() {
   it("should work even on arrays of doubles", function() {
     expect(bs([0.0, 0.1, 0.2, 0.3, 0.4], 0.25, cmp)).to.equal(-4);
   });
+
+  it("should pass the index as third parameter to the comparator", function() {
+    var indexes = [],
+        indexCmp = function(a, b, i) { indexes.push(i); return cmp(a, b); };
+    bs(arr, 3, indexCmp);
+    expect(indexes).to.deep.equal([3, 5, 4])
+  });
 });

--- a/test.js
+++ b/test.js
@@ -33,9 +33,13 @@ describe("binarysearch", function() {
     expect(bs([0.0, 0.1, 0.2, 0.3, 0.4], 0.25, cmp)).to.equal(-4);
   });
 
-  it("should pass the index as third parameter to the comparator", function() {
+  it("should pass the index and array parameters to the comparator", function() {
     var indexes = [],
-        indexCmp = function(a, b, i) { indexes.push(i); return cmp(a, b); };
+        indexCmp = function(a, b, i, array) {
+          expect(array).to.equal(arr);
+          indexes.push(i);
+          return cmp(a, b);
+        };
     bs(arr, 3, indexCmp);
     expect(indexes).to.deep.equal([3, 5, 4])
   });


### PR DESCRIPTION
In some very weird cases, it would be handy to have the index and array instead of just the value in the comparator (My use case in particular is to search within text nodes in Atom, which has API methods that operate on indexes). This is a trivial addition and shouldn't break any dependent code, so it can be a minor semver update.

Added a test and updated documentation to reflect the change. Also updated the devDependencies and added a script so that it's easier to run tests by just running `npm test`.