### PR TITLE
Add typings definition for use with typescript

### DIFF
--- a/binary-search.d.ts
+++ b/binary-search.d.ts
@@ -1,0 +1,18 @@
+//Typescript type definition for:
+//https://github.com/darkskyapp/binary-search
+declare module 'binary-search' {
+
+const enum compareResult {
+  lessThan = -1,
+  greaterThan = 1,
+  same = 0
+}
+
+function binarySearch<A>(
+  haystack: A[],
+  needle: A,
+  comparator: (a: A, b: A, index?: number, haystack?: A[]) => compareResult,
+  low?: number,
+  high?: number): number; //returns index of found result or number < 0 if not found
+export = binarySearch;
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.3.0",
   "description": "tiny binary search function with comparators",
   "license": "CC0-1.0",
+  "typings": "./binary-search.d.ts",
   "author": {
     "name": "The Dark Sky Company, LLC",
     "email": "support@darkskyapp.com"


### PR DESCRIPTION
With this typescript type definition it can be used with typescript.

```typescript
import binarySearch from 'binary-search';
```

See https://www.typescriptlang.org/docs/handbook/typings-for-npm-packages.html