### PR TITLE
Use ArrayLike<A> instead of A[]

### DIFF
--- a/binary-search.d.ts
+++ b/binary-search.d.ts
@@ -3,7 +3,7 @@
 declare module 'binary-search' {
 
 function binarySearch<A, B>(
-  haystack: A[],
+  haystack: ArrayLike<A>,
   needle: B,
   comparator: (a: A, b: B, index?: number, haystack?: A[]) => any,
   // Notes about comparator return value:


### PR DESCRIPTION
This enables the array to be a ReadonlyArray as well as a normal array.