### PR TITLE
Bug fix for huge arrays

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,9 +20,10 @@ module.exports = function(haystack, needle, comparator, low, high) {
   }
 
   while(low <= high) {
-    /* Note that "(low + high) >>> 1" may overflow, and results in a typecast
-     * to double (which gives the wrong results). */
-    mid = low + (high - low >> 1);
+    /* low + high >>> 1 could fail for array lengths > 2**31 because >>>
+     * converts its operands to int32. low - (high - low >>> 1) works for
+     * array lengths < 2**32 which is also Javascript's max array length. */
+    mid = low + (high - low >>> 1);
     cmp = +comparator(haystack[mid], needle, mid, haystack);
 
     /* Too low. */


### PR DESCRIPTION
## TL;DR
Replaces a sign-propagating right shift operator with a zero-fill right shift operator to fix a bug for huge arrays. Also improves the comment about overflow.

## The bug
See also #2 and 9169835adb574842b209e0fbe1584fe080e77bc2.

The problem is that [bit shift operators convert their operands to 32-bit integers](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Bitwise_Operators#Bitwise_shift_operators).

The original code
```javascript
mid = (low + high) >>> 1
```
is affected by this when `low + high >= 2**32` which could happen if `haystack.length > 2**31` whereas [Javascript allows array lengths up to `2**32 - 1` (inclusive)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array#Parameters).

In an attempt to improve the situation 9169835adb574842b209e0fbe1584fe080e77bc2 changed the code to:
```javascript
mid = low + ((high - low) >> 1)
```
However, as mentioned before bit shift operators convert their operands to 32-bit integers. Note that those are 32-bit _signed_ integers. Thus integers between `2**31` and `2**32 - 1` (inclusive) are converted to negative numbers as their most significant bit is erroneously interpreted as a negative sign. The sign-propagating right shift operator then propagates this error to the result.

The new code is affected by that when `high - low >= 2**31` which reliably happens if `haystack.length > 2**31`. That's the same condition we had for the original code, but while under this condition the original code might still succeed in some cases, the new code will reliably fail. So 9169835adb574842b209e0fbe1584fe080e77bc2 actually only made things worse.

## The fix
Fortunately the problem is easily fixed by using the zero-fill right shift operator instead.
```javascript
mid = low + (high - low >>> 1)
```
The operand is still converted to a 32-bit signed integer, but for integers between `2**31` and `2**32 - 1` (inclusive) this is now of no consequence as the zero-filling exactly counteracts the conversion error. Therefore this code won't be affected by the conversion to 32-bit integers unless `high - low >= 2**32` which cannot happen because it would require `haystack.length` to be greater than Javascript's maximum array length of `2**32 - 1`.

The following demonstrates the bug and the fix:
```javascript
let [low, high] = [0, 2**31 + 2];
console.log(
    (low + high) / 2,
    low + (high - low >> 1),
    low + (high - low >>> 1)
);
// 1073741825 -1073741823 1073741825
```